### PR TITLE
[FIX] : conditionally renderd Oauth with google only for firefox users

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,11 +1,23 @@
+"use client"
 import { DotPattern } from '@/components/magicui/dot-pattern'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 const AuthLayout = ({ children }: { children: React.ReactNode }) => {
+  const [isFirefox, setIsFirefox] = useState(false)
+
+  useEffect(() => {
+    setIsFirefox(navigator.userAgent.includes('Firefox'))
+  }, [])
+
   return (
     <div className='flex items-center justify-center w-screen h-screen'>
-      <DotPattern glow={true} />
-      {children}</div>
+      {isFirefox ? (
+        <div className="absolute inset-0 h-full w-full bg-gradient-to-b from-[#1e1d1d] to-[#090b0c] overflow-hidden" />
+      ) : (
+        <DotPattern glow={true} />
+      )}
+      {children}
+    </div>
   )
 }
 

--- a/components/auth/sign-in.tsx
+++ b/components/auth/sign-in.tsx
@@ -18,6 +18,12 @@ const SignIn = () => {
   const [error, setError] = useState("")
   const [success, setSuccess] = useState("")
   const [loading, setLoading] = useState(false)
+  const [isFirefox, setIsFirefox] = useState(false)
+
+  useEffect(() => {
+    const userAgent = window.navigator.userAgent.toLowerCase()
+    setIsFirefox(userAgent.indexOf('firefox') > -1)
+  }, [])
 
   useEffect(() => {
     setError("")
@@ -102,27 +108,29 @@ const SignIn = () => {
             priority
           />
         </div>
-        
+
         {/* Title */}
         <h2 className='text-2xl font-bold text-center text-[#7b7b7d]'>
-          Sign up to create notes with 
+          Sign in to create notes with
         </h2>
         <AuroraText colors={["#FFBB94", "#DC586D", "#FB9590"]} className="font-bold text-4xl font-inter">FONA</AuroraText>
-        
+
         <div className='w-full space-y-4'>
           <FormError message={error} />
           <FormSuccess message={success} />
-          
-          <Button
-            variant='outline'
-            className='w-full flex items-center justify-center gap-2 h-12 text-base text-[#7b7b7d] hover:text-white hover:bg-[#242424] transition-colors bg-[#191919] border-[#292929]'
-            onClick={googleSignIn}
-            disabled={loading}
-          >
-            <FcGoogle className='w-6 h-6' />
-            Continue with Google
-          </Button>
-          
+
+          {!isFirefox && (
+            <Button
+              variant='outline'
+              className='w-full flex items-center justify-center gap-2 h-12 text-base text-[#7b7b7d] hover:text-white hover:bg-[#242424] transition-colors bg-[#191919] border-[#292929]'
+              onClick={googleSignIn}
+              disabled={loading}
+            >
+              <FcGoogle className='w-6 h-6' />
+              Continue with Google
+            </Button>
+          )}
+
           <Button
             variant='outline'
             className='w-full flex items-center justify-center gap-2 h-12 text-base text-[#7b7b7d] hover:text-white hover:bg-[#242424] transition-colors bg-[#191919] border-[#292929]'

--- a/components/auth/sign-up.tsx
+++ b/components/auth/sign-up.tsx
@@ -18,11 +18,20 @@ const SignUp = () => {
   const [error, setError] = useState("")
   const [success, setSuccess] = useState("")
   const [loading, setLoading] = useState(false)
+  const [isFirefox, setIsFirefox] = useState(false)
 
   useEffect(() => {
     setError("")
     setSuccess("")
     setLoading(false)
+  }, [])
+
+
+
+  useEffect(() => {
+    // Check if the browser is Firefox
+    const userAgent = window.navigator.userAgent.toLowerCase()
+    setIsFirefox(userAgent.indexOf('firefox') > -1)
   }, [])
 
   const githubSignIn = async () => {
@@ -104,27 +113,29 @@ const SignUp = () => {
             priority
           />
         </div>
-        
+
         {/* Title */}
         <h2 className='text-2xl font-bold text-center text-[#7b7b7d]'>
           Create an account with
         </h2>
         <AuroraText colors={["#FFBB94", "#DC586D", "#FB9590"]} className="font-bold text-4xl font-inter">FONA</AuroraText>
-        
+
         <div className='w-full space-y-4'>
           <FormError message={error} />
           <FormSuccess message={success} />
-          
-          <Button
-            variant='outline'
-            className='w-full flex items-center justify-center gap-2 h-12 text-base text-[#7b7b7d] hover:text-white hover:bg-[#242424] transition-colors bg-[#191919] border-[#292929]'
-            onClick={googleSignIn}
-            disabled={loading}
-          >
-            <FcGoogle className='w-6 h-6' />
-            Continue with Google
-          </Button>
-          
+
+          {!isFirefox && (
+            <Button
+              variant='outline'
+              className='w-full flex items-center justify-center gap-2 h-12 text-base text-[#7b7b7d] hover:text-white hover:bg-[#242424] transition-colors bg-[#191919] border-[#292929]'
+              onClick={googleSignIn}
+              disabled={loading}
+            >
+              <FcGoogle className='w-6 h-6' />
+              Continue with Google
+            </Button>
+          )}
+
           <Button
             variant='outline'
             className='w-full flex items-center justify-center gap-2 h-12 text-base text-[#7b7b7d] hover:text-white hover:bg-[#242424] transition-colors bg-[#191919] border-[#292929]'

--- a/middleware.ts
+++ b/middleware.ts
@@ -45,7 +45,7 @@ export async function middleware(request: NextRequest) {
   if (pathname === "/dashboard" || pathname.startsWith("/editor/")) {
     const sessionCookie = getSessionCookie(request);
     if (!sessionCookie) {
-      return NextResponse.redirect(new URL("/signin", request.url));
+      return NextResponse.redirect(new URL("/signup", request.url));
     }
   }
 


### PR DESCRIPTION
### conditionally renderd Oauth with google only for firefox users

**why?**

since rn Google OAuth on Firefox, where clicking the Google login button results in no action (likely due to NS_BINDING_ABORTED)

**the main issue found is something related to** 
- Firefox's strict popup blocking and third-party cookie restrictions conflicting with Better Auth's Google OAuth implementation, which uses a popup-based PKCE flow.


since rn we have not comeup with a concrete solution we are opting for github auth option for firefox users 

but chromium based web browser users still have both options to log in for 


**NOTE -** 
We will try to resolve the issue as soon as possible ! 